### PR TITLE
Added command to turn on/off remote logging

### DIFF
--- a/monitor/management/commands/readCheck.py
+++ b/monitor/management/commands/readCheck.py
@@ -11,7 +11,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
 
         read_expected = True #Assume need a reading
-        active_config = Config.objects.get(pk=1)      
+        active_config = Config.objects.filter()[:1].get()      
         read_missing = active_config.read_missing        
         read_last_instant = active_config.read_last_instant
         right_now = datetime.datetime.now()

--- a/monitor/middleware.py
+++ b/monitor/middleware.py
@@ -93,6 +93,19 @@ send2middleware("L")	= ('Success', 'Data collection on.')
 send2middleware("L")	= ('Fail', 'Was already on.')
 
 ----------------------------------------------------------------
+
+E - Turns off remote logging, continues to add logs to queue
+
+send2middleware("E")	= ('Success', 'Remote logging off.')
+send2middleware("E")	= ('Fail', 'Remote logging was already off.')
+----------------------------------------------------------------
+
+D - Turns on remote logging
+
+send2middleware("D")	= ('Success', 'Remote logging on.')
+send2middleware("D")	= ('Fail', 'Remote logging was already on.')
+
+----------------------------------------------------------------
 !!DEFUNCT!!
 C - Turns off server permanently, will require access to the server to turn it back on
 

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -283,8 +283,8 @@ def commands(request):
                        ('r=pres_beer','Value of pres_beer'),
                        ('l','Turn data collection on'),
                        ('o','Turn data collection off'),
-					   ('d','Turn remote logging on'),
-					   ('e','Turn remote logging off')
+                       ('d','Turn remote logging on'),
+                       ('e','Turn remote logging off')
                       ]
 
     data = {

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -192,7 +192,7 @@ def api(request):
     key = stringFromPost(request, 'key')
     if (key == 'beer') or (key == 'test'):
 
-        active_config = Config.objects.filter()[:1].get() #Get config 1
+        active_config = Config.objects.get(pk=1) #Get config 1
         active_beer = active_config.beer #Get active beer
 
         read = Reading(beer=active_beer) #Create reading record

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -192,7 +192,7 @@ def api(request):
     key = stringFromPost(request, 'key')
     if (key == 'beer') or (key == 'test'):
 
-        active_config = Config.objects.get(pk=1) #Get config 1
+        active_config = Config.objects.filter()[:1].get() #Get config 1
         active_beer = active_config.beer #Get active beer
 
         read = Reading(beer=active_beer) #Create reading record

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -284,7 +284,7 @@ def commands(request):
                        ('l','Turn data collection on'),
                        ('o','Turn data collection off'),
 					   ('d','Turn remote logging on'),
-                       ('e','Turn remote logging off')
+					   ('e','Turn remote logging off')
                       ]
 
     data = {

--- a/monitor/views.py
+++ b/monitor/views.py
@@ -281,8 +281,10 @@ def commands(request):
                        ('r=temp_beer','Value of temp_beer'),
                        ('r=light_amb','Value of light_amb'),
                        ('r=pres_beer','Value of pres_beer'),
-                       ('l','Turn logging on'),
-                       ('o','Turn logging off'),
+                       ('l','Turn data collection on'),
+                       ('o','Turn data collection off'),
+					   ('d','Turn remote logging on'),
+                       ('e','Turn remote logging off')
                       ]
 
     data = {


### PR DESCRIPTION
Use "e" to turn off remote logging (forces all logs to queue) and "d" to
turn it back on.